### PR TITLE
Don't cache dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,14 +44,6 @@ jobs:
       - run: yarn cypress cache path
       # should return empty list of installed versions
       - run: yarn cypress cache list
-      # restore / cache the binary ourselves on Linux
-      # see https://github.com/actions/cache
-      - name: Cache Cypress
-        id: cache-cypress
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/Cypress
-          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
       # now let's install Cypress binary
       - run: yarn cypress install
       - run: yarn cypress cache list
@@ -126,14 +118,6 @@ jobs:
       - run: yarn cypress cache path
       # should return empty list of installed versions
       - run: yarn cypress cache list
-      # restore / cache the binary ourselves on Linux
-      # see https://github.com/actions/cache
-      - name: Cache Cypress
-        id: cache-cypress
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/Cypress
-          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
       # now let's install Cypress binary
       - run: yarn cypress install
       - run: yarn cypress cache list
@@ -187,14 +171,6 @@ jobs:
       - run: yarn cypress cache path
       # should return empty list of installed versions
       - run: yarn cypress cache list
-      # restore / cache the binary ourselves on Linux
-      # see https://github.com/actions/cache
-      - name: Cache Cypress
-        id: cache-cypress
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/Cypress
-          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
       # now let's install Cypress binary
       - run: yarn cypress install
       - run: yarn cypress cache list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,6 @@ jobs:
         run: yarn
 
       - uses: bahmutov/npm-install@v1
-        env:
-          CYPRESS_INSTALL_BINARY: 0
       # confirm there is no Cypress installed
       - run: yarn cypress cache path
       # should return empty list of installed versions
@@ -124,8 +122,6 @@ jobs:
         run: yarn
 
       - uses: bahmutov/npm-install@v1
-        env:
-          CYPRESS_INSTALL_BINARY: 0
       # confirm there is no Cypress installed
       - run: yarn cypress cache path
       # should return empty list of installed versions
@@ -187,8 +183,6 @@ jobs:
         run: yarn
 
       - uses: bahmutov/npm-install@v1
-        env:
-          CYPRESS_INSTALL_BINARY: 0
       # confirm there is no Cypress installed
       - run: yarn cypress cache path
       # should return empty list of installed versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,15 +25,6 @@ jobs:
         with:
           node-version: 14.18.1
 
-      # Cache dependencies
-      - name: Cache Dependencies
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: |
-            **/node_modules
-          key: yarn-${{ hashFiles('**/package.json', 'yarn.lock') }}
-
       # Install project dependencies
       - name: Install Dependencies
         # if: steps.cache.outputs.cache-hit != 'true'
@@ -99,15 +90,6 @@ jobs:
         with:
           node-version: 14.18.1
 
-      # Cache dependencies
-      - name: Cache Dependencies
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: |
-            **/node_modules
-          key: yarn-${{ hashFiles('**/package.json', 'yarn.lock') }}
-
       # Install project dependencies
       - name: Install Dependencies
         # if: steps.cache.outputs.cache-hit != 'true'
@@ -151,15 +133,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14.18.1
-
-      # Cache dependencies
-      - name: Cache Dependencies
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: |
-            **/node_modules
-          key: yarn-${{ hashFiles('**/package.json', 'yarn.lock') }}
 
       # Install project dependencies
       - name: Install Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       # should return empty list of installed versions
       - run: yarn cypress cache list
       # now let's install Cypress binary
-      - run: yarn cypress install
+      - run: yarn cypress install --force
       - run: yarn cypress cache list
 
       - name: Build
@@ -101,7 +101,7 @@ jobs:
       # should return empty list of installed versions
       - run: yarn cypress cache list
       # now let's install Cypress binary
-      - run: yarn cypress install
+      - run: yarn cypress install --force
       - run: yarn cypress cache list
 
       - name: Build
@@ -145,7 +145,7 @@ jobs:
       # should return empty list of installed versions
       - run: yarn cypress cache list
       # now let's install Cypress binary
-      - run: yarn cypress install
+      - run: yarn cypress install --force
       - run: yarn cypress cache list
 
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Install project dependencies
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        # if: steps.cache.outputs.cache-hit != 'true'
         run: yarn
 
       - uses: bahmutov/npm-install@v1
@@ -120,7 +120,7 @@ jobs:
 
       # Install project dependencies
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        # if: steps.cache.outputs.cache-hit != 'true'
         run: yarn
 
       - uses: bahmutov/npm-install@v1
@@ -183,7 +183,7 @@ jobs:
 
       # Install project dependencies
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        # if: steps.cache.outputs.cache-hit != 'true'
         run: yarn
 
       - uses: bahmutov/npm-install@v1


### PR DESCRIPTION
Noticed a pattern between passing ([1](https://github.com/replayio/shepherd/actions/runs/3297843555/jobs/5439177788), [2](https://github.com/replayio/shepherd/actions/runs/3482802919/jobs/5825558619), [3](https://github.com/replayio/shepherd/actions/runs/3651999396/jobs/6169872399)) and failing ([1](https://github.com/replayio/shepherd/actions/runs/3690784296)) runs: the failing ones use the cached dependencies and skip the install step.